### PR TITLE
Fix usage output and add teleport message

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -1,9 +1,8 @@
 name: HubCommand
-main: HubCommand\Main
-version: 2.0
+main: HubCommand\HubCommand
+version: 1#
 api: 3.0.0
 author: IceCruelStuff, iStrafeNubzHDyt
-load: STARTUP
 
 commands:
     hub:

--- a/src/HubCommand/HubCommand.php
+++ b/src/HubCommand/HubCommand.php
@@ -5,10 +5,9 @@ namespace HubCommand;
 use pocketmine\command\Command;
 use pocketmine\command\CommandSender;
 use pocketmine\plugin\PluginBase;
-use pocketmine\utils\TextFormat;
 use pocketmine\Player;
 
-class Main extends PluginBase {
+class HubCommand extends PluginBase {
 
     public function onCommand(CommandSender $sender, Command $command, string $label, array $args) : bool {
         $spawnLocation = $this->getServer()->getDefaultLevel()->getSpawnLocation();
@@ -17,12 +16,14 @@ class Main extends PluginBase {
             case "lobby":
                 if ($sender instanceof Player) {
                     $sender->getPlayer()->teleport($spawnLocation);
+                    $sender->sendMessage("§aDu wirst zur Lobby teleportiert...");
                 } else {
                     $sender->sendMessage("Please use this command in-game");
                 }
+                return true;
                 break;
         }
-        return false;
+        return true;
     }
 
 }


### PR DESCRIPTION
This removes the usage output that should not be showed when teleporting to hub